### PR TITLE
Changed interpreter path

### DIFF
--- a/vspec2c.py
+++ b/vspec2c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 #
 # (C) 2019 Jaguar Land Rover

--- a/vspec2cnative.py
+++ b/vspec2cnative.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 #
 # (C) 2020 Geotab Inc
@@ -165,4 +165,3 @@ if __name__ == "__main__":
         exit(255)
 
     traverse_tree(tree)
-

--- a/vspec2csv.py
+++ b/vspec2csv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 #
 #

--- a/vspec2franca.py
+++ b/vspec2franca.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 #
 # (C) 2016 Jaguar Land Rover

--- a/vspec2json.py
+++ b/vspec2json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 #
 # (C) 2016 Jaguar Land Rover


### PR DESCRIPTION
Using env instead of direct python path
in order to make it more independent of the
python installation and underlying distribution.

Fixes: #11