### PR TITLE
Feature/json to anytree

### DIFF
--- a/vspec2json.py
+++ b/vspec2json.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 #
-# (C) 2016 Jaguar Land Rover
+# (c) 2016 Jaguar Land Rover
+# (c) 2021 Robert Bosch GmbH
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
@@ -14,6 +15,8 @@ import sys
 import vspec
 import json
 import getopt
+from model.vsstree import VSSNode, VSSType
+
 
 def usage():
     print("Usage:", sys.argv[0], "[-I include_dir] ... [-i prefix:id_file] vspec_file json_file")
@@ -27,6 +30,67 @@ def usage():
     print(" vspec_file            The vehicle specification file to parse.")
     print(" json_file             The file to output the JSON objects to.")
     sys.exit(255)
+
+
+
+def export_node(json_dict, node):
+    
+    json_dict[node.name]={}
+
+    if node.type == VSSType.SENSOR or node.type == VSSType.ACTUATOR or node.type == VSSType.ATTRIBUTE:
+        json_dict[node.name]["datatype"]=str(node.data_type.value)
+
+    json_dict[node.name]["type"]=str(node.type.value)
+
+    #many optional attributes are initilized to "" in vsstree.py
+    if node.min != "":
+        json_dict[node.name]["min"]=node.min
+    if node.max != "":
+        json_dict[node.name]["max"]=node.max
+    if node.enum != "":
+        json_dict[node.name]["enum"]=node.enum
+    if node.default_value != "":
+        json_dict[node.name]["default"]=node.default_value
+    if node.value != "":
+        json_dict[node.name]["value"]=node.value
+    if node.deprecation != "":
+        json_dict[node.name]["deprecation"]=node.deprecation
+
+   
+    #in case of unit or aggregate, the attribute will be missing
+    try: 
+        json_dict[node.name]["unit"]=str(node.unit.value)
+    except AttributeError:
+        pass
+    try: 
+        json_dict[node.name]["aggregate"]=node.aggregate
+    except AttributeError:
+        pass
+
+
+
+    json_dict[node.name]["description"]=node.description
+    json_dict[node.name]["uuid"]=node.uuid
+    
+    #Might be better to not generate child dict, if there are no children
+    #if node.type == VSSType.BRANCH and len(node.children) != 0:
+    #    json_dict[node.name]["children"]={}
+
+    #But old JSON code always generates children, so lets do so to
+    if node.type == VSSType.BRANCH:
+        json_dict[node.name]["children"]={}
+
+
+    for child in node.children:
+        export_node(json_dict[node.name]["children"], child)
+
+    
+
+def export_json(file, root):
+    json_dict={}
+    export_node(json_dict,root)
+    json.dump(json_dict,file, indent=2, sort_keys=True)
+
 
 if __name__ == "__main__":
     #
@@ -55,12 +119,13 @@ if __name__ == "__main__":
 
     json_out = open (args[1], "w")
 
-    try:
-        tree = vspec.load(args[0], include_dirs)
-    except vspec.VSpecError as e:
-        print("Error: {}".format(e))
-        exit(255)
 
-    json.dump(tree, json_out, indent=2)
-    json_out.write("\n")
-    json_out.close()
+    try:
+        print("Loading vspec...")
+        tree = vspec.load_tree(args[0], include_dirs)
+        print("Recursing tree and creating JSON...")
+        export_json(json_out,tree)
+        print("All done.")
+    except vspec.VSpecError as e:
+        print(f"Error: {e}")
+        exit(255)


### PR DESCRIPTION
This ports JSON generation to the "new" anytree based parser. (It performs more checks, and the old one is deprecated)

It fixes 1 bug in anytree vspec parser: Deprecation is supported now

The created file is almost identical to compare change the line

```python
    json.dump(tree, json_out, indent=2)
```

in the old version to 

```python
    json.dump(tree, json_out, indent=2, sort_keys=True)
```

This gives the following  diff 

```diff
--- new.json    2021-02-09 12:27:34.693521102 +0100
+++ old.json    2021-02-09 12:02:03.687367155 +0100
@@ -12031,6 +12031,12 @@
         "type": "branch",
         "uuid": "12f35ec7bd1c58d1a329565ce3d053d5"
       },
+      "Private": {
+        "children": {},
+        "description": "Uncontrolled branch where non-public signals can be defined.",
+        "type": "branch",
+        "uuid": "4161866b048a5b76aa3124dec82e0260"
+      },
       "RoofLoad": {
         "datatype": "int16",
         "description": "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.",
@@ -12256,4 +12262,4 @@
     "type": "branch",
     "uuid": "ccc825f94139544dbb5f4bfd033bece6"
   }
-}
\ No newline at end of file
+}
```

Because it i seems, the anytree parser seems to ignore it. I am not quite sure why (because it generate empty "media")
Anyway, as long as you can not prove it is my fault, I consider it a separate bug :)