### PR TITLE
FIx CSV build failure (vsstree.py: Add deprecation key)

### DIFF
--- a/model/vsstree.py
+++ b/model/vsstree.py
@@ -83,6 +83,9 @@ class VSSNode(Node):
         if "instances" in source_dict.keys():
             self.instances = source_dict["instances"]
 
+        if "deprecation" in source_dict.keys():
+            self.deprecation = source_dict["deprecation"]
+
     def is_private(self) -> bool:
         """Checks weather this instance is in private branch of VSS.
 
@@ -231,7 +234,7 @@ class VSSNode(Node):
 
         for aKey in element.keys():
             if aKey not in ["type", "children", "datatype", "description", "unit", "uuid", "min", "max", "enum",
-                            "aggregate", "default", "value", "instances"]:
+                            "aggregate", "default", "value", "instances", "deprecation"]:
                 raise Exception("Unsupported attribute tree element %s found: %s" % (name, aKey))
 
 


### PR DESCRIPTION
The CSV converter was failing because the new deprecation: key was
unknown.  

Other converters also use vsstree definition, so I think this affects more
things, but it is noticed when Travis fails for CSV.
