### PR TITLE
Feature/parser check core attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
   # Now test compilation with this vss-tools and the master branch of VSS
   - cd vehicle_signal_specification
   - /usr/bin/env python3 --version
-  - make clean json deploy
+  - make clean json franca binary csv deploy

--- a/vspec.py
+++ b/vspec.py
@@ -242,7 +242,7 @@ def convert_yaml_to_list(raw_yaml):
 
 
 
-def load_tree(file_name, include_paths):
+def load_tree(file_name, include_paths, exclude_private=False, break_on_noncore_attribute=False):
     flat_model = load_flat_model(file_name, "", include_paths)
     flat_model_instances = expand_instances(flat_model)
     absolute_path_flat_model = create_absolute_paths(flat_model_instances)
@@ -250,7 +250,7 @@ def load_tree(file_name, include_paths):
     deep_model = create_nested_model(absolute_path_flat_model_with_id, file_name)
     cleanup_deep_model(deep_model)
     dict_tree = deep_model["children"]
-    return render_tree(dict_tree, True)
+    return render_tree(dict_tree, exclude_private, break_on_noncore_attribute=break_on_noncore_attribute)
 
 
 def load_flat_model(file_name, prefix, include_paths):
@@ -784,28 +784,28 @@ $include$:
     return text
 
 
-def render_tree(tree_dict, merge_private=False) -> VSSNode:
+def render_tree(tree_dict, merge_private=False, break_on_noncore_attribute=False) -> VSSNode:
     if len(tree_dict) != 1:
         raise Exception('Invalid VSS model, must have single root node')
 
     root_element_name = next(iter(tree_dict.keys()))
     root_element = tree_dict[root_element_name]
-    tree_root = VSSNode(root_element_name, root_element)
+    tree_root = VSSNode(root_element_name, root_element, break_on_noncore_attribute=break_on_noncore_attribute)
 
     if "children" in root_element.keys():
         child_nodes = root_element["children"]
-        render_subtree(child_nodes, tree_root)
+        render_subtree(child_nodes, tree_root, break_on_noncore_attribute=break_on_noncore_attribute)
 
     if merge_private:
         merge_private_into_main_tree(tree_root)
     return tree_root
 
 
-def render_subtree(subtree, parent):
+def render_subtree(subtree, parent, break_on_noncore_attribute=False):
     for element_name in subtree:
         current_element = subtree[element_name]
 
-        new_element = VSSNode(element_name, current_element, parent=parent)
+        new_element = VSSNode(element_name, current_element, parent=parent, break_on_noncore_attribute=break_on_noncore_attribute)
         if "children" in current_element.keys():
             child_nodes = current_element["children"]
             render_subtree(child_nodes, new_element)

--- a/vspec2json.py
+++ b/vspec2json.py
@@ -19,7 +19,8 @@ from model.vsstree import VSSNode, VSSType
 
 
 def usage():
-    print("Usage:", sys.argv[0], "[-I include_dir] ... [-i prefix:id_file] vspec_file [-s] json_file")
+    print(
+        "Usage:", sys.argv[0], "[-I include_dir] ... [-i prefix:id_file] vspec_file [-s] json_file")
     print("  -s                   Use strict checking: Terminate when non-core attribute is found")
     print("  -I include_dir       Add include directory to search for included vspec")
     print("                       files. Can be used multiple timees.")
@@ -33,70 +34,64 @@ def usage():
     sys.exit(255)
 
 
-
 def export_node(json_dict, node):
 
-    json_dict[node.name]={}
+    json_dict[node.name] = {}
 
     if node.type == VSSType.SENSOR or node.type == VSSType.ACTUATOR or node.type == VSSType.ATTRIBUTE:
-        json_dict[node.name]["datatype"]=str(node.data_type.value)
+        json_dict[node.name]["datatype"] = str(node.data_type.value)
 
-    json_dict[node.name]["type"]=str(node.type.value)
+    json_dict[node.name]["type"] = str(node.type.value)
 
-    #many optional attributes are initilized to "" in vsstree.py
+    # many optional attributes are initilized to "" in vsstree.py
     if node.min != "":
-        json_dict[node.name]["min"]=node.min
+        json_dict[node.name]["min"] = node.min
     if node.max != "":
-        json_dict[node.name]["max"]=node.max
+        json_dict[node.name]["max"] = node.max
     if node.enum != "":
-        json_dict[node.name]["enum"]=node.enum
+        json_dict[node.name]["enum"] = node.enum
     if node.default_value != "":
-        json_dict[node.name]["default"]=node.default_value
+        json_dict[node.name]["default"] = node.default_value
     if node.deprecation != "":
-        json_dict[node.name]["deprecation"]=node.deprecation
+        json_dict[node.name]["deprecation"] = node.deprecation
 
-
-    #in case of unit or aggregate, the attribute will be missing
+    # in case of unit or aggregate, the attribute will be missing
     try:
-        json_dict[node.name]["unit"]=str(node.unit.value)
+        json_dict[node.name]["unit"] = str(node.unit.value)
     except AttributeError:
         pass
     try:
-        json_dict[node.name]["aggregate"]=node.aggregate
+        json_dict[node.name]["aggregate"] = node.aggregate
     except AttributeError:
         pass
 
+    json_dict[node.name]["description"] = node.description
+    json_dict[node.name]["uuid"] = node.uuid
 
-
-    json_dict[node.name]["description"]=node.description
-    json_dict[node.name]["uuid"]=node.uuid
-
-    #Might be better to not generate child dict, if there are no children
-    #if node.type == VSSType.BRANCH and len(node.children) != 0:
+    # Might be better to not generate child dict, if there are no children
+    # if node.type == VSSType.BRANCH and len(node.children) != 0:
     #    json_dict[node.name]["children"]={}
 
-    #But old JSON code always generates children, so lets do so to
+    # But old JSON code always generates children, so lets do so to
     if node.type == VSSType.BRANCH:
-        json_dict[node.name]["children"]={}
-
+        json_dict[node.name]["children"] = {}
 
     for child in node.children:
         export_node(json_dict[node.name]["children"], child)
 
 
-
 def export_json(file, root):
-    json_dict={}
-    export_node(json_dict,root)
-    json.dump(json_dict,file, indent=2, sort_keys=True)
+    json_dict = {}
+    export_node(json_dict, root)
+    json.dump(json_dict, file, indent=2, sort_keys=True)
 
 
 if __name__ == "__main__":
     #
     # Check that we have the correct arguments
     #
-    opts, args= getopt.getopt(sys.argv[1:], "sI:i:")
-    strict=False
+    opts, args = getopt.getopt(sys.argv[1:], "sI:i:")
+    strict = False
 
     # Always search current directory for include_file
     include_dirs = ["."]
@@ -111,21 +106,21 @@ if __name__ == "__main__":
             [prefix, file_name] = id_spec
             vspec.db_mgr.create_signal_uuid_db(prefix, file_name)
         elif o == "-s":
-            strict=True
+            strict = True
         else:
             usage()
 
     if len(args) != 2:
         usage()
 
-    json_out = open (args[1], "w")
-
+    json_out = open(args[1], "w")
 
     try:
         print("Loading vspec...")
-        tree = vspec.load_tree(args[0], include_dirs, exclude_private=False, break_on_noncore_attribute=strict)
+        tree = vspec.load_tree(
+            args[0], include_dirs, exclude_private=False, break_on_noncore_attribute=strict)
         print("Recursing tree and creating JSON...")
-        export_json(json_out,tree)
+        export_json(json_out, tree)
         print("All done.")
     except vspec.VSpecError as e:
         print(f"Error: {e}")


### PR DESCRIPTION
This fixes #38 

merge order #34  #35  and then this

This does not change the default behaviour (i.e. CSV parser not changed, output the same), but will print warnings if non-core attribtes are found.

With current vspec

```
$ python3 vspec2json.py  -i :test.id -I ../vehicle_signal_specification/spec/ ../spec/VehicleSignalSpecification.vspec    vsstest.json
Loading vspec...
Warning: Non-core attribute "value" in elment CurrentOverallWeight found.
Warning: Non-core attribute "value" in elment CurbWeight found.
Warning: Non-core attribute "value" in elment GrossWeight found.
Warning: Non-core attribute "value" in elment MaxTowWeight found.
Warning: Non-core attribute "value" in elment MaxTowBallWeight found.
Warning: Non-core attribute "value" in elment Length found.
Warning: Non-core attribute "value" in elment Height found.
Warning: Non-core attribute "value" in elment Width found.
Warning: Non-core attribute "value" in elment ChargePortFlap found.
Warning: Non-core attribute "value" in elment ChargePlugType found.
Warning: Non-core attribute "value" in elment Mode found.
Warning: Non-core attribute "value" in elment StartStopCharging found.
Warning: Non-core attribute "value" in elment Mode found.
Recursing tree and creating JSON...
All done.
```
(for layers non-core attributes might be desired)

Once all spec bugs are fixed, we can switch Travis to run strict mode with `-s` parameter

```
python3 vspec2json.py -s  -i :test.id -I ../vehicle_signal_specification/spec/ ../spec/VehicleSignalSpecification.vspec    vsstest.json
Loading vspec...
Warning: Non-core attribute "value" in elment CurrentOverallWeight found.
You asked for strict checking. Terminating.
```
@danielwilms  pls check