### PR TITLE
Align travis file with counterpart in vss

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
   # Now test compilation with this vss-tools and the master branch of VSS
   - cd vehicle_signal_specification
   - /usr/bin/env python3 --version
-  - make clean json franca binary csv tests deploy
+  - make travis_targets


### PR DESCRIPTION
With this you only need to change Makefile in vehicle_signal_specification to change the targets run by travis.

This is the same change as done in .travis.yml in vehicle_signal_specification recently