### PR TITLE
Fix module searchpath

### DIFF
--- a/contrib/vspec2protobuf.py
+++ b/contrib/vspec2protobuf.py
@@ -10,6 +10,11 @@
 #
 
 import sys
+import os
+#Add path to main py vspec  parser
+myDir= os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(myDir, ".."))
+
 import vspec
 import getopt
 from anytree import RenderTree, PreOrderIter


### PR DESCRIPTION
Fixes #50 

(I think this is better than setting environments in Makefile as it would be surprising to a user if it only runs correctly when starting from a specific Makefile)