### PR TITLE
Make optional targets also for vss-tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ script:
   - cd vehicle_signal_specification
   - /usr/bin/env python3 --version
   - make travis_targets
+  - make -k travis_optional || true


### PR DESCRIPTION
Now when Makefile in vss has been updated we can use the new target
also in vss-tools, to detect problems as soon as possible.