### PR TITLE
Checking correct use of default

### DIFF
--- a/model/vsstree.py
+++ b/model/vsstree.py
@@ -251,6 +251,9 @@ class VSSNode(Node):
                             "aggregate", "default" , "instances", "deprecation", "arraysize"]:
                 raise NonCoreAttributeException('Non-core attribute "%s" in element %s found.' % (aKey, name))
 
+        if "default" in element.keys():
+            if element["type"] != "attribute":
+                raise NonCoreAttributeException("Invalid VSS element %s, only attributes can use default" % name)
 
 def camel_case(st):
     """Camel case string conversion"""


### PR DESCRIPTION
To detect misuse as described in
https://github.com/GENIVI/vehicle_signal_specification/issues/283

Gives just a warning unless you use a strict check

example from travis build for current vss:
```
Loading vspec...
Warning: Invalid VSS element CurrentOverallWeight, only attributes can use default
Warning: Invalid VSS element ChargePortFlap, only attributes can use default
Warning: Invalid VSS element Mode, only attributes can use default
Warning: Invalid VSS element StartStopCharging, only attributes can use default
Warning: Invalid VSS element Mode, only attributes can use default
```