### PR TITLE
Bugfix: Added collections dependency

### DIFF
--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -15,6 +15,7 @@ import os
 import uuid
 import sys
 import re
+import collections
 
 from anytree import (Resolver, ChildResolverError, LevelOrderIter)
 import deprecation


### PR DESCRIPTION
When using the yaml dictionaries instead of lists
then the dependency is necessary.

Was removed in #4497a47.

Needed for VSS [issue 149](https://github.com/GENIVI/vehicle_signal_specification/issues/149)

Signed-off-by: Daniel Wilms <Daniel.DW.Wilms@bmw.de>