### PR TITLE
Removing uuid parameter support

### DIFF
--- a/contrib/vspec2c.py
+++ b/contrib/vspec2c.py
@@ -17,13 +17,9 @@ import getopt
 import hashlib
 import json
 def usage():
-    print("Usage:", sys.argv[0], "[-I include-dir] ... [-i prefix:id-file] vspec-file output-header-file output-macro-file")
+    print("Usage:", sys.argv[0], "[-I include-dir] ... vspec-file output-header-file output-macro-file")
     print("  -I include-dir       Add include directory to search for included vspec")
     print("                       files. Can be used multiple timees.")
-    print()
-    print("  -i prefix:uuid-file  File to use for storing generated UUIDs for signals with")
-    print("                       a given path prefix. Can be used multiple times to store")
-    print("                       UUIDs for signal sub-trees in different files.")
     print()
     print(" output-header-file    The file to output the signal spec-encoding header info to.")
     sys.exit(255)
@@ -283,21 +279,13 @@ if __name__ == "__main__":
     #
     # Check that we have the correct arguments
     #
-    opts, args= getopt.getopt(sys.argv[1:], "I:i:")
+    opts, args= getopt.getopt(sys.argv[1:], "I:")
 
     # Always search current directory for include_file
     include_dirs = ["."]
     for o, a in opts:
         if o == "-I":
             include_dirs.append(a)
-        elif o == "-i":
-            id_spec = a.split(":")
-            if len(id_spec) != 2:
-                print("ERROR: -i needs a 'prefix:id_file' argument.")
-                usage()
-
-            [prefix, file_name] = id_spec
-            vspec.db_mgr.create_signal_uuid_db(prefix, file_name)
         else:
             usage()
 

--- a/contrib/vspec2protobuf.py
+++ b/contrib/vspec2protobuf.py
@@ -49,14 +49,9 @@ def print_message_body(nodes, proto_file):
 
 def usage():
     print(
-        """Usage: vspec2protobuf.py [-I include_dir] ... [-i prefix:id_file] vspec_file output_file
+        """Usage: vspec2protobuf.py [-I include_dir] ... vspec_file output_file
   -I include_dir       Add include directory to search for included vspec
                        files. Can be used multiple times.
-
-  -i prefix:uuid_file  File to use for storing generated UUIDs for signals with
-                       a given path prefix. Can be used multiple times to store
-                       UUIDs for signal sub-trees in different files.
-
  vspec_file            The vehicle specification file to parse.
  proto_file            The file to output the proto file to.)
        """
@@ -68,21 +63,13 @@ if __name__ == "__main__":
     #
     # Check that we have the correct arguments
     #
-    opts, args = getopt.getopt(sys.argv[1:], "I:i:")
+    opts, args = getopt.getopt(sys.argv[1:], "I:")
 
     # Always search current directory for include_file
     include_dirs = ["."]
     for o, a in opts:
         if o == "-I":
             include_dirs.append(a)
-        elif o == "-i":
-            id_spec = a.split(":")
-            if len(id_spec) != 2:
-                print("ERROR: -i needs a 'prefix:id_file' argument.")
-                usage()
-
-            [prefix, file_name] = id_spec
-            vspec.db_mgr.create_signal_uuid_db(prefix, file_name)
         else:
             usage()
 

--- a/contrib/vspec2ttl/vspec2ttl.py
+++ b/contrib/vspec2ttl/vspec2ttl.py
@@ -45,18 +45,6 @@ Usage: {sys.argv[0]} [options] vspec_file ttl_file
   -I include_dir       Add include directory to search for included vspec
                        files. Can be used multiple timees.
 
-  -i prefix:uuid_file  "prefix" is an optional string that will be
-                       prepended to each signal name defined in the
-                       vspec file.
-
-                       "uuid_file" is the name of the file containing the
-                       static UUID values for the signals.  This file is
-                       read/write and will be updated if necessary.
-
-                       This option can be specified several times in
-                       to store the UUIDs of different parts of the
-                       signal tree in different files.
-
   vspec_file           The vehicle specification file to parse.
 
   ttl_file             The file to output the ttl data to.
@@ -288,21 +276,13 @@ if __name__ == "__main__":
     #
     # Check that we have the correct arguments
     #
-    opts, args = getopt.getopt(sys.argv[1:], "I:i:")
+    opts, args = getopt.getopt(sys.argv[1:], "I:")
 
     # Always search current directory for include_file
     include_dirs = ["."]
     for o, a in opts:
         if o == "-I":
             include_dirs.append(a)
-        elif o == "-i":
-            id_spec = a.split(":")
-            if len(id_spec) != 2:
-                print("ERROR: -i needs a 'prefix:id_file' argument.")
-                usage()
-
-            [prefix, file_name] = id_spec
-            vspec.db_mgr.create_signal_uuid_db(prefix, file_name)
         else:
             usage()
 

--- a/vspec2binary.py
+++ b/vspec2binary.py
@@ -20,13 +20,9 @@ import getopt
 import ctypes
 
 def usage():
-    print(("Usage:", sys.argv[0], "[-I include_dir] ... [-i prefix:id_file] vspec_file franca_file"))
+    print(("Usage:", sys.argv[0], "[-I include_dir] ... vspec_file franca_file"))
     print ("  -I include_dir       Add include directory to search for included vspec")
     print ("                       files. Can be used multiple timees.")
-    print ("\n")
-    print ("  -i prefix:uuid_file  File to use for storing generated UUIDs for signals with")
-    print ("                       a given path prefix. Can be used multiple times to store")
-    print ("                       UUIDs for signal sub-trees in different files.")
     print ("\n")
     print (" vspec_file            The vehicle specification file to parse.")
     print (" franca_file           The file to output the Franca IDL spec to.")
@@ -137,7 +133,7 @@ if __name__ == "__main__":
     #
     # Check that we have the correct arguments
     #
-    opts, args= getopt.getopt(sys.argv[1:], "I:i:v:")
+    opts, args= getopt.getopt(sys.argv[1:], "I:v:")
 
     # Always search current directory for include_file
     vss_version = "unspecified version"
@@ -147,14 +143,6 @@ if __name__ == "__main__":
             include_dirs.append(a)
         elif o == "-v":
             vss_version = a
-        elif o == "-i":
-            id_spec = a.split(":")
-            if len(id_spec) != 2:
-                print ("ERROR: -i needs a 'prefix:id_file' argument.")
-                usage()
-
-            [prefix, file_name] = id_spec
-            vspec.db_mgr.create_signal_uuid_db(prefix, file_name)
         else:
             usage()
 

--- a/vspec2csv.py
+++ b/vspec2csv.py
@@ -79,21 +79,13 @@ if __name__ == "__main__":
     #
     # Check that we have the correct arguments
     #
-    opts, args = getopt.getopt(sys.argv[1:], "I:i:")
+    opts, args = getopt.getopt(sys.argv[1:], "I:")
 
     # Always search current directory for include_file
     include_dirs = ["."]
     for o, a in opts:
         if o == "-I":
             include_dirs.append(a)
-        elif o == "-i":
-            id_spec = a.split(":")
-            if len(id_spec) != 2:
-                print("ERROR: -i needs a 'prefix:id_file' argument.")
-                usage()
-
-            [prefix, file_name] = id_spec
-            vspec.db_mgr.create_signal_uuid_db(prefix, file_name)
         else:
             usage()
 

--- a/vspec2franca.py
+++ b/vspec2franca.py
@@ -16,13 +16,9 @@ import json
 import getopt
 
 def usage():
-    print("Usage:", sys.argv[0], "[-I include_dir] ... [-i prefix:id_file] vspec_file franca_file")
+    print("Usage:", sys.argv[0], "[-I include_dir] ... vspec_file franca_file")
     print("  -I include_dir       Add include directory to search for included vspec")
     print("                       files. Can be used multiple timees.")
-    print()
-    print("  -i prefix:uuid_file  File to use for storing generated UUIDs for signals with")
-    print("                       a given path prefix. Can be used multiple times to store")
-    print("                       UUIDs for signal sub-trees in different files.")
     print()
     print(" vspec_file            The vehicle specification file to parse.")
     print(" franca_file           The file to output the Franca IDL spec to.")
@@ -94,7 +90,7 @@ if __name__ == "__main__":
     #
     # Check that we have the correct arguments
     #
-    opts, args= getopt.getopt(sys.argv[1:], "I:i:v:")
+    opts, args= getopt.getopt(sys.argv[1:], "I:v:")
 
     # Always search current directory for include_file
     vss_version = "unspecified version"
@@ -104,14 +100,6 @@ if __name__ == "__main__":
             include_dirs.append(a)
         elif o == "-v":
             vss_version = a
-        elif o == "-i":
-            id_spec = a.split(":")
-            if len(id_spec) != 2:
-                print("ERROR: -i needs a 'prefix:uuid_file' argument.")
-                usage()
-
-            [prefix, file_name] = id_spec
-            vspec.db_mgr.create_signal_uuid_db(prefix, file_name)
         else:
             usage()
 

--- a/vspec2json.py
+++ b/vspec2json.py
@@ -20,14 +20,10 @@ from vspec.model.vsstree import VSSNode, VSSType
 
 def usage():
     print(
-        "Usage:", sys.argv[0], "[-I include_dir] ... [-i prefix:id_file] vspec_file [-s] json_file")
+        "Usage:", sys.argv[0], "[-I include_dir] ... vspec_file [-s] json_file")
     print("  -s                   Use strict checking: Terminate when non-core attribute is found")
     print("  -I include_dir       Add include directory to search for included vspec")
     print("                       files. Can be used multiple timees.")
-    print()
-    print("  -i prefix:uuid_file  File to use for storing generated UUIDs for signals with")
-    print("                       a given path prefix. Can be used multiple times to store")
-    print("                       UUIDs for signal sub-trees in different files.")
     print()
     print(" vspec_file            The vehicle specification file to parse.")
     print(" json_file             The file to output the JSON objects to.")
@@ -90,7 +86,7 @@ if __name__ == "__main__":
     #
     # Check that we have the correct arguments
     #
-    opts, args = getopt.getopt(sys.argv[1:], "sI:i:")
+    opts, args = getopt.getopt(sys.argv[1:], "sI:")
     strict = False
 
     # Always search current directory for include_file
@@ -98,13 +94,6 @@ if __name__ == "__main__":
     for o, a in opts:
         if o == "-I":
             include_dirs.append(a)
-        elif o == "-i":
-            id_spec = a.split(":")
-            if len(id_spec) != 2:
-                print("ERROR: -i needs a 'prefix:id_file' argument.")
-                usage()
-            [prefix, file_name] = id_spec
-            vspec.db_mgr.create_signal_uuid_db(prefix, file_name)
         elif o == "-s":
             strict = True
         else:


### PR DESCRIPTION
We discussed at a previous meeting that the id-parameter in tools is not used and does not make sense. Here is a change reflecting that. Parameter support is being removed, but internal model of creating UUID remains.

Intermediate build problems expected as make-files needs to be adapted to the change