### PR TITLE
README.md: add link to VSS Tools section of official online VSS doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # VSS Tools Usage
 
+Additional information can be found in the official VSS documentation at: [VSS Tools](https://genivi.github.io/vehicle_signal_specification/tools/)
+
 ## Contents
 1. Prerequisites
 2. Project Setup


### PR DESCRIPTION
The official online VSS documentation contains a section on the VSS Tools.
Follow the pattern set by the VSS README.md and link to it to aid
discoverability by newcomers.
