### PR TITLE
Adding the datatypes HSVColor and DateTime.

### DIFF
--- a/tests/model/test_contants.py
+++ b/tests/model/test_contants.py
@@ -105,6 +105,8 @@ class TestConstantsNode(unittest.TestCase):
         self.assertEqual(VSSDataType.DOUBLE, VSSDataType.from_str("double"))
         self.assertEqual(VSSDataType.STRING, VSSDataType.from_str("string"))
         self.assertEqual(VSSDataType.UNIX_TIMESTAMP, VSSDataType.from_str("UNIX Timestamp"))
+        self.assertEqual(VSSDataType.DATETIME, VSSDataType.from_str("DateTime"))
+        self.assertEqual(VSSDataType.HSVCOLOR, VSSDataType.from_str("HSVColor"))
 
     def test_invalid_vss_data_types(self):
         with self.assertRaises(Exception): VSSDataType.from_str("not_a_valid_case")

--- a/vspec/model/constants.py
+++ b/vspec/model/constants.py
@@ -141,6 +141,8 @@ class VSSDataType(Enum):
     DOUBLE_ARRAY = "double[]"
     STRING_ARRAY = "string[]"
     UNIX_TIMESTAMP_ARRAY = "UNIX Timestamp[]"
+    DATETIME = "DateTime"
+    HSVCOLOR = "HSVColor"
 
     @staticmethod
     def from_str(name):


### PR DESCRIPTION
Adding the datatypes HSVColor and DateTime.

The type DateTime is added according to the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
The type HSVColor is added according to the [HSL Format](https://drafts.csswg.org/css-color/#the-hsl-notation)
resolves #76
