### PR TITLE
Adding the units for illuminance, frequency and time, following the SI

### DIFF
--- a/tests/model/test_contants.py
+++ b/tests/model/test_contants.py
@@ -47,6 +47,7 @@ class TestConstantsNode(unittest.TestCase):
         self.assertEqual(Unit.VOLT, Unit.from_str("V"))
         self.assertEqual(Unit.AMPERE, Unit.from_str("A"))
         self.assertEqual(Unit.SECOND, Unit.from_str("s"))
+        self.assertEqual(Unit.MILLISECOND, Unit.from_str("ms"))
         self.assertEqual(Unit.MINUTE, Unit.from_str("min"))
         self.assertEqual(Unit.WEEKS, Unit.from_str("weeks"))
         self.assertEqual(Unit.MONTHS, Unit.from_str("months"))
@@ -68,6 +69,9 @@ class TestConstantsNode(unittest.TestCase):
         self.assertEqual(Unit.REVOLUTIONSPERMINUTE, Unit.from_str("rpm"))
         self.assertEqual(Unit.INCH, Unit.from_str("inch"))
         self.assertEqual(Unit.RATIO, Unit.from_str("ratio"))
+        self.assertEqual(Unit.HERTZ, Unit.from_str("Hz"))
+        self.assertEqual(Unit.LUX, Unit.from_str("lx"))
+        self.assertEqual(Unit.MILLIBAR, Unit.from_str("mbar"))
 
     def test_invalid_unit(self):
         with self.assertRaises(Exception): Unit.from_str("not_a_valid_case")

--- a/vspec/model/constants.py
+++ b/vspec/model/constants.py
@@ -60,6 +60,7 @@ class Unit(Enum):
     VOLT = "V"
     AMPERE = "A"
     SECOND = "s"
+    MILLISECOND = "ms"
     MINUTE = "min"
     WEEKS = "weeks"
     MONTHS = "months"
@@ -81,6 +82,9 @@ class Unit(Enum):
     REVOLUTIONSPERMINUTE = "rpm"
     INCH = "inch"
     RATIO = "ratio"
+    HERTZ = "Hz"
+    LUX = "lx"
+    MILLIBAR = "mbar"
 
     @staticmethod
     def from_str(name):


### PR DESCRIPTION
 Adding the units for illuminance, frequency, and time, following the SI notation as described in [International_System_of_Units wiki page](https://en.wikipedia.org/wiki/International_System_of_Units#Units_and_prefixes.)

Adding the following units:
 - Lux as 'lx'
 - Hertz as 'Hz'
 - Millisecond as 'ms'
resolves #76
