### PR TITLE
Using separator "/" at qualified_name()

### DIFF
--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -745,11 +745,11 @@ def detect_and_merge(tree_root: VSSNode, private_root: VSSNode):
         if not private_element.is_private():
             continue
 
-        element_name = "/" + private_element.qualified_name()
+        element_name = "/" + private_element.qualified_name("/")
         candidate_name = element_name.replace("Private/", "")
 
         if not VSSNode.node_exists(tree_root, candidate_name):
-            new_parent_name = "/" + private_element.parent.qualified_name().replace("/Private", "")
+            new_parent_name = "/" + private_element.parent.qualified_name("/").replace("/Private", "")
             new_parent = r.get(tree_root, new_parent_name)
             private_element.parent = new_parent
 


### PR DESCRIPTION
Using separator "/ "in detect_and_merge(), since later the name
generated is used by a resolver that gives an error when called
with DEFAULT_SEPARATOR ".".
resolves #82