### PR TITLE
Renaming exclude_private to merge_private

### DIFF
--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -155,7 +155,7 @@ def convert_yaml_to_list(raw_yaml):
 
 
 
-def load_tree(file_name, include_paths, exclude_private=False, break_on_noncore_attribute=False):
+def load_tree(file_name, include_paths, merge_private=False, break_on_noncore_attribute=False):
     flat_model = load_flat_model(file_name, "", include_paths)
     flat_model_instances = expand_instances(flat_model)
     absolute_path_flat_model = create_absolute_paths(flat_model_instances)
@@ -163,7 +163,7 @@ def load_tree(file_name, include_paths, exclude_private=False, break_on_noncore_
     deep_model = create_nested_model(absolute_path_flat_model_with_id, file_name)
     cleanup_deep_model(deep_model)
     dict_tree = deep_model["children"]
-    return render_tree(dict_tree, exclude_private, break_on_noncore_attribute=break_on_noncore_attribute)
+    return render_tree(dict_tree, merge_private, break_on_noncore_attribute=break_on_noncore_attribute)
 
 
 def load_flat_model(file_name, prefix, include_paths):

--- a/vspec2json.py
+++ b/vspec2json.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
     try:
         print("Loading vspec...")
         tree = vspec.load_tree(
-            args[0], include_dirs, exclude_private=False, break_on_noncore_attribute=strict)
+            args[0], include_dirs, merge_private=False, break_on_noncore_attribute=strict)
         print("Recursing tree and creating JSON...")
         export_json(json_out, tree)
         print("All done.")


### PR DESCRIPTION
The parameter exclude_private in load_tree() is being passed to the
render_tree() function as merge_private. This behavior can confuse
the programmer since both names mean opposite ideas. The real behavior
is that the variable merges Private if it's true, so this commit
corrects this bug just by changing the variable name.

Resolves #85