### PR TITLE
Changing undefined behavior of include_dirs

### DIFF
--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -255,7 +255,9 @@ def load_flat_model(file_name, prefix, include_paths):
     check_yaml_usage(raw_yaml, file_name)
 
     # Recursively expand all include files.
-    expanded_includes = expand_includes(raw_yaml, prefix, list(set(include_paths + [directory])))
+    if directory not in include_paths:
+        include_paths = [directory] + include_paths
+    expanded_includes = expand_includes(raw_yaml, prefix, include_paths)
 
     # Add type: branch when type is missing.
     flat_model = cleanup_flat_entries(expanded_includes)


### PR DESCRIPTION
In the line

https://github.com/GENIVI/vss-tools/blob/14d044699bc358590009aaf1740864c149d3c9be/vspec/init.py#L258

The function `expand_includes()` is called with the include_paths updated with the current file's directory with `list(set(include_paths + [directory]))`.

It happens that set is an unordered data structure, and it does not guarantee to preserve order when a list is transformed into a `dict` and back to a `list`, causing the argument `include_paths` to have undefined order.

Later in `search_and_read()`, files will be searched following the order of `include_paths`, which is undefined. This way if you cannot expect to have any preference between the paths in `include_paths`.

In that way, if you have two files with the same name (common case when we talk about the files in the Private folder) and run the code, it will be uncertain if one file or another will be included.

In this case, the wanted behavior is to look at the current working directory first, and then at others.